### PR TITLE
replace capturelog with pytest-catchlog to remove warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
-pytest-capturelog
+pytest-catchlog
 pytest-instafail
 pytest-mock
 selenium


### PR DESCRIPTION
This will remove the warnings found at the end of test runs with failures while using the same logging functionality (see [pytest-catchlog](https://github.com/eisensheng/pytest-catchlog) for more details)