### PR TITLE
wrapped up selenium keys in a neater form

### DIFF
--- a/nerodia/__init__.py
+++ b/nerodia/__init__.py
@@ -33,6 +33,11 @@ logger = Logger()
 
 _str_types = (six.binary_type, six.text_type)
 
+#
+# Wrap up selenium keys object for simplicity
+#
+
+from selenium.webdriver.common.keys import Keys  # noqa
 
 from . import tag_map  # noqa
 

--- a/nerodia/keys.py
+++ b/nerodia/keys.py
@@ -1,3 +1,0 @@
-import selenium
-
-Keys = selenium.webdriver.common.keys.Keys

--- a/nerodia/keys.py
+++ b/nerodia/keys.py
@@ -1,5 +1,3 @@
 import selenium
 
 Keys = selenium.webdriver.common.keys.Keys
-
-

--- a/nerodia/keys.py
+++ b/nerodia/keys.py
@@ -1,0 +1,5 @@
+import selenium
+
+Keys = selenium.webdriver.common.keys.Keys
+
+

--- a/tests/unit/keys_tests.py
+++ b/tests/unit/keys_tests.py
@@ -1,11 +1,14 @@
-import pytest
+import six
 
 
 from nerodia.keys import Keys
 
 
 def test_can_access_keys():
-    assert Keys.TAB == '\ue004'
+    if six.PY3:
+        assert Keys.TAB == '\ue004'
+    else:
+        assert Keys.TAB == '\\\ue004'
 
 
 def test_keys_exists():

--- a/tests/unit/keys_tests.py
+++ b/tests/unit/keys_tests.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+from nerodia.keys import Keys
+
+
+def test_can_access_keys():
+    assert Keys.TAB == '\ue004'
+
+
+def test_keys_exists():
+    assert isinstance(Keys, object)

--- a/tests/unit/keys_tests.py
+++ b/tests/unit/keys_tests.py
@@ -1,9 +1,0 @@
-from nerodia.keys import Keys
-
-
-def test_can_access_keys():
-        assert Keys.TAB == u'\ue004'
-    
-
-def test_keys_exists():
-    assert isinstance(Keys, object)

--- a/tests/unit/keys_tests.py
+++ b/tests/unit/keys_tests.py
@@ -1,15 +1,9 @@
-import six
-
-
 from nerodia.keys import Keys
 
 
 def test_can_access_keys():
-    if six.PY3:
-        assert Keys.TAB == '\ue004'
-    else:
-        assert Keys.TAB == '\\\ue004'
-
+        assert Keys.TAB == u'\ue004'
+    
 
 def test_keys_exists():
     assert isinstance(Keys, object)


### PR DESCRIPTION
Based on some comments from a user, I wrapped the `selenium.webdriver.common.keys` object into a more user-friendly form in Nerodia.